### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ I strongly recommend you to compile by yourself for Linux distributions as Linux
 
     ```sh
     # For Debian/Ubuntu:
-    sudo apt install libusb-1.0.0
+    sudo apt install libusb-1.0-0
     ```
 
     ```sh
@@ -265,7 +265,7 @@ I strongly recommend you to compile by yourself for Linux distributions as Linux
 
     ```sh
     # For Debian/Ubuntu:
-    sudo apt install golang-go libusb-1.0.0-dev
+    sudo apt install golang-go libusb-1.0-0-dev
     ```
 
     ```sh


### PR DESCRIPTION
in the readme.md, the dependency should be libusb-1.0-0 and libusb-1.0-0-dev instead of libusb-1.0.0 and libusb-1.0.0-dev
(hyphen instead of dot near the end)
it was the reason for the tool not working in my case
this PR closes #14 