### PR TITLE
Fix max resolution

### DIFF
--- a/mtp/nikon.go
+++ b/mtp/nikon.go
@@ -29,7 +29,15 @@ const (
 )
 
 type RecordingMedia int8
-type Resolution     uint64
+type Resolution64 uint64
+type Resolution8    uint8
+
+type ResolutionType int
+
+const (
+	ResolutionType64 ResolutionType = iota
+	ResolutionType8
+)
 
 const (
 	RecordingMediaCard  RecordingMedia = 0
@@ -39,6 +47,7 @@ const (
 type Model struct {
 	Name             string
 	HeaderSize       int
+	ResolutionType   ResolutionType
 	QuirkSwitchMedia bool
 }
 
@@ -119,6 +128,11 @@ var models = ModelMap{
 		Name:       "D5600",
 		HeaderSize: 384,
 	},
+	"D6": {
+		Name:       "D6",
+		HeaderSize: 384,
+		ResolutionType: ResolutionType8,
+	},
 	"D600": {
 		Name:       "D600",
 		HeaderSize: 384,
@@ -134,6 +148,11 @@ var models = ModelMap{
 	"D750": {
 		Name:       "D750",
 		HeaderSize: 384,
+	},
+	"D780": {
+		Name:       "D780",
+		HeaderSize: 384,
+		ResolutionType: ResolutionType8,
 	},
 	"D7000": {
 		Name:       "D7000",
@@ -151,9 +170,36 @@ var models = ModelMap{
 	"Z6": {
 		Name:       "Z6",
 		HeaderSize: 384,
+		ResolutionType: ResolutionType8,
+	},
+	"Z6II": {
+		Name:       "Z6II",
+		HeaderSize: 384,
+		ResolutionType: ResolutionType8,
 	},
 	"Z7": {
 		Name:       "Z7",
 		HeaderSize: 384,
+		ResolutionType: ResolutionType8,
+	},
+	"Z7II": {
+		Name:       "Z7II",
+		HeaderSize: 384,
+		ResolutionType: ResolutionType8,
+	},
+	"Z9": {
+		Name:       "Z9",
+		HeaderSize: 384,
+		ResolutionType: ResolutionType8,
+	},
+	"Z50": {
+		Name:       "Z50",
+		HeaderSize: 384,
+		ResolutionType: ResolutionType8,
+	},
+	"Zfc": {
+		Name:       "Zfc",
+		HeaderSize: 384,
+		ResolutionType: ResolutionType8,
 	},
 }

--- a/mtp/server.go
+++ b/mtp/server.go
@@ -559,11 +559,24 @@ func (s *LVServer) changeResolution() error {
 	log.LV.Infof("available resolutions (higher is larger): %v", choices)
 	log.LV.Infof("automatically use the largest choice: %d", choices[len(choices)-1])
 
-	payload := struct {
-		Resolution Resolution
-	}{
-		Resolution: Resolution(choices[len(choices)-1]),
+
+	var payload interface{}
+
+	switch s.model.ResolutionType {
+	case ResolutionType64:
+		payload = struct {
+			Resolution Resolution64
+		}{
+			Resolution: Resolution64(choices[len(choices)-1]),
+		}
+	case ResolutionType8:
+		payload = struct {
+			Resolution Resolution8
+		}{
+			Resolution: Resolution8(choices[len(choices)-1]),
+		}
 	}
+
 	err = s.dev.SetDevicePropValue(DPC_NIKON_Resolution, &payload)
 	if err != nil {
 		return fmt.Errorf("failed to SetDevicePropValue: %s", err)

--- a/mtp/server.go
+++ b/mtp/server.go
@@ -486,7 +486,7 @@ func (s *LVServer) startLiveView() error {
 	if s.maxResolution {
 		err = s.changeResolution()
 		if err != nil {
-			log.LV.Warningf("failed to change the image resolution (%s); if it affects capturing frames, consider disabling `-max-resolution`")
+			log.LV.Warningf("failed to change the image resolution (%s); if it affects capturing frames, consider disabling `-max-resolution`", err)
 		}
 	}
 


### PR DESCRIPTION
Some recent models expect uint8 value for the resolution enum.
While not all models that didn't accept uint64 enum (models marked by 🤔 in the table in README) may accept uint8, I experimentally enable uint8 enum for these models.