### PR TITLE
Add MJPEG stream and snapshot support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
 [*.{js,css,html}]
 indent_style = space
 indent_size = 2
+
+[*.go]
+indent_style = tab

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func main() {
 		_, _ = io.Copy(w, f)
 	})
 	router.HandleFunc("/view.mjpeg", lvs.HandleMotionJPEG)
+	router.HandleFunc("/snapshot", lvs.HandleSnapshot)
 	router.HandleFunc("/stream", lvs.HandleStream)
 	router.HandleFunc("/control", lvs.HandleControl)
 	router.Handle("/assets/", http.FileServer(public.Root))

--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func main() {
 		f, _ := public.Root.Open("/index.html")
 		_, _ = io.Copy(w, f)
 	})
-	router.HandleFunc("/view.mjpeg", lvs.HandleMotionJPEG)
+	router.HandleFunc("/mjpeg", lvs.HandleMotionJPEG)
 	router.HandleFunc("/snapshot", lvs.HandleSnapshot)
 	router.HandleFunc("/stream", lvs.HandleStream)
 	router.HandleFunc("/control", lvs.HandleControl)

--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ func main() {
 		f, _ := public.Root.Open("/index.html")
 		_, _ = io.Copy(w, f)
 	})
+	router.HandleFunc("/view.mjpeg", lvs.HandleMotionJPEG)
 	router.HandleFunc("/stream", lvs.HandleStream)
 	router.HandleFunc("/control", lvs.HandleControl)
 	router.Handle("/assets/", http.FileServer(public.Root))

--- a/mtp/mjpeg.go
+++ b/mtp/mjpeg.go
@@ -16,7 +16,7 @@ type MJPEGResponseWriter struct {
 func NewMJPEGResponseWriter(w http.ResponseWriter) *MJPEGResponseWriter {
 	boundary := randomBoundary()
 
-	w.Header().Set("Content-Type", "multipart/x-mixed-replace; boundary=" + boundary)
+	w.Header().Set("Content-Type", "multipart/x-mixed-replace; boundary="+boundary)
 
 	return &MJPEGResponseWriter{
 		boundary: boundary,

--- a/mtp/mjpeg.go
+++ b/mtp/mjpeg.go
@@ -1,0 +1,49 @@
+package mtp
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+type MJPEGResponseWriter struct {
+	boundary string
+	w        http.ResponseWriter
+}
+
+func NewMJPEGResponseWriter(w http.ResponseWriter) *MJPEGResponseWriter {
+	boundary := randomBoundary()
+
+	w.Header().Set("Content-Type", "multipart/x-mixed-replace; boundary=" + boundary)
+
+	return &MJPEGResponseWriter{
+		boundary: boundary,
+		w:        w,
+	}
+}
+
+func (m *MJPEGResponseWriter) Write(jpeg []byte) error {
+	f, ok := m.w.(http.Flusher)
+	if !ok {
+		return fmt.Errorf("HTTP buffer flushing is not implemented")
+	}
+
+	m.w.Write([]byte("Content-Type: image/jpeg\r\nContent-Length: " + strconv.Itoa(len(jpeg)) + "\r\n\r\n"))
+	m.w.Write(jpeg)
+	m.w.Write([]byte("\r\n--" + m.boundary + "\r\n"))
+
+	f.Flush()
+
+	return nil
+}
+
+func randomBoundary() string {
+	var buf [30]byte
+	_, err := io.ReadFull(rand.Reader, buf[:])
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%x", buf[:])
+}

--- a/mtp/server.go
+++ b/mtp/server.go
@@ -36,9 +36,9 @@ type LVServer struct {
 	streamLock      sync.Mutex
 	controlClients  map[*websocket.Conn]bool
 	controlLock     sync.Mutex
-    motionClients   map[*MJPEGResponseWriter]bool
+	motionClients   map[*MJPEGResponseWriter]bool
 	motionLock      sync.Mutex
-    snapshotClients map[*SnapshotResponseWriter]bool
+	snapshotClients map[*SnapshotResponseWriter]bool
 	snapshotLock    sync.Mutex
 
 	model         Model
@@ -238,7 +238,7 @@ func (s *LVServer) unregisterControlClient(c *websocket.Conn) {
 }
 
 func (s *LVServer) HandleMotionJPEG(w http.ResponseWriter, r *http.Request) {
-	log.LV.Info("handling GET /view.jpeg")
+	log.LV.Info("handling GET /mjpeg")
 
 	writer := NewMJPEGResponseWriter(w)
 	s.registerMotionClient(writer)
@@ -459,19 +459,19 @@ func (s *LVServer) workerBroadcastFrame() error {
 			}
 		}
 
-        for w := range s.motionClients {
+		for w := range s.motionClients {
 			err := w.Write(jpeg)
 			if err != nil {
 				log.LV.Errorf("workerBroadcastFrame: failed to send a frame: %s", err)
 			}
-        }
+		}
 
-        for w := range s.snapshotClients {
+		for w := range s.snapshotClients {
 			err := w.Write(jpeg)
 			if err != nil {
 				log.LV.Errorf("workerBroadcastFrame: failed to send a frame: %s", err)
 			}
-        }
+		}
 	}
 
 	for {

--- a/mtp/snapshot.go
+++ b/mtp/snapshot.go
@@ -1,0 +1,32 @@
+package mtp
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+type SnapshotResponseWriter struct {
+	Context context.Context
+	cancel  context.CancelFunc
+	w       http.ResponseWriter
+}
+
+func NewSnapshotResponseWriter(w http.ResponseWriter) *SnapshotResponseWriter {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel = context.WithCancel(ctx)
+
+	return &SnapshotResponseWriter{
+		Context: ctx,
+		cancel:  cancel,
+		w:       w,
+	}
+}
+
+func (s *SnapshotResponseWriter) Write(jpeg []byte) error {
+	s.w.Header().Set("Content-Type", "image/jpeg")
+	s.w.Write(jpeg)
+	s.cancel()
+
+	return nil
+}


### PR DESCRIPTION
Love the work you've done here! I wanted to use my Nikon camera along with [OctoPrint](https://octoprint.org/) for some sweet timelapse videos of 3D prints. But their software expects an MJPEG stream and a way to capture JPEG snapshots. So I added endpoints for both of these:

* `/mjpeg` - Provides an MJPEG stream straight from the camera, same as what the websocket endpoint sends
* `/snapshot` - Provides the latest JPEG image taken from the sensor after the request is made

Not sure if this would fit into your main project scope, but wanted to provide it back in case others find it useful. :)