### PR TITLE
Update README and camera model detection for Nikon Z series

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -54,8 +54,8 @@ mtplvcapとOBSを組み合わせることで、NikonのカメラをHDMIキャプ
 |Z6   |Yes          |:white_check_mark:|:white_check_mark:|@ShadowXii|
 |Z6II |Yes          |:white_check_mark:|:thinking:        |@puhitaku|
 |Z7   |Yes          |:white_check_mark:|:thinking:        |@zacheadams|
-|Z7II |Yes          |:white_check_mark:|:thinking:        |@puhitaku|
-|Z9   |Yes          |                  |?                 |未発売だが多分動く :wink:|
+|Z7II |Yes          |:white_check_mark:|:white_check_mark:|@puhitaku|
+|Z9   |Yes          |:white_check_mark:|:white_check_mark:|@oxpa|
 |Z50  |Yes          |:white_check_mark:|:thinking:        |@puhitaku|
 |Z fc |Yes          |:white_check_mark:|:white_check_mark:|@puhitaku|
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ mtplvcap + OBS turn your cameras into web cameras without HDMI capture device. E
 |Z6   |Yes          |:white_check_mark:|:white_check_mark:|@ShadowXii|
 |Z6II |Yes          |:white_check_mark:|:thinking:        |@puhitaku|
 |Z7   |Yes          |:white_check_mark:|:thinking:        |@zacheadams|
-|Z7II |Yes          |:white_check_mark:|:thinking:        |@puhitaku|
-|Z9   |Yes          |                  |?                 |It's not sold yet but hopefully works :wink:|
+|Z7II |Yes          |:white_check_mark:|:white_check_mark:|@puhitaku|
+|Z9   |Yes          |:white_check_mark:|:white_check_mark:|@oxpa|
 |Z50  |Yes          |:white_check_mark:|:thinking:        |@puhitaku|
 |Z fc |Yes          |:white_check_mark:|:white_check_mark:|@puhitaku|
 

--- a/mtp/nikon.go
+++ b/mtp/nikon.go
@@ -167,37 +167,37 @@ var models = ModelMap{
 		HeaderSize:       128,
 		QuirkSwitchMedia: true,
 	},
-	"Z6": {
+	"6": {
 		Name:           "Z6",
 		HeaderSize:     384,
 		ResolutionType: ResolutionType8,
 	},
-	"Z6II": {
+	"6_2": {
 		Name:           "Z6II",
 		HeaderSize:     384,
 		ResolutionType: ResolutionType8,
 	},
-	"Z7": {
+	"7": {
 		Name:           "Z7",
 		HeaderSize:     384,
 		ResolutionType: ResolutionType8,
 	},
-	"Z7II": {
+	"7_2": {
 		Name:           "Z7II",
 		HeaderSize:     384,
 		ResolutionType: ResolutionType8,
 	},
-	"Z9": {
+	"9": {
 		Name:           "Z9",
 		HeaderSize:     384,
 		ResolutionType: ResolutionType8,
 	},
-	"Z50": {
+	"50": {
 		Name:           "Z50",
 		HeaderSize:     384,
 		ResolutionType: ResolutionType8,
 	},
-	"Zfc": {
+	"fc": {
 		Name:           "Zfc",
 		HeaderSize:     384,
 		ResolutionType: ResolutionType8,


### PR DESCRIPTION
Hello,

In models.go edits for Z6, Z7, Z6II and Zfc were not verified.
But changes for Z7II, Z9 and Z50 are correct.

I also believe that all Z series cameras will work properly with higher resolutions so 'thinking face' can be safely swapped for white check mark.

I have also updated the README files with the data I checked.

Do let me know if I have to change anything more and
Thank you! 