### PR TITLE
Let users run mtplvcap direct from GitHub

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/README.md
+++ b/README.md
@@ -296,12 +296,8 @@ I strongly recommend you to compile by yourself for Linux distributions as Linux
 
     ```sh
     # If you have Nix installed, with Flakes enabled:
-    nix run github:r-k-b/mtplvcap?ref=add-nix-flake -- -debug server
+    nix run github:puhitaku/mtplvcap -- -debug server
     ```
-
-_Note: `github:r-k-b/mtplvcap?ref=add-nix-flake` to be replaced with
-`github:puhitaku/mtplvcap`, after these changes are merged to puhitaku's main branch._
-
 
 For non-[Nix] Linux, see the rest of the instructions:
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,22 @@ To revert it back, follow the instruction:
 I strongly recommend you to compile by yourself for Linux distributions as Linux environments vary widely.
 
 
+#### Run direct from GitHub
+
+    ```sh
+    # If you have Nix installed, with Flakes enabled:
+    nix run github:r-k-b/mtplvcap?ref=add-nix-flake -- -debug server
+    ```
+
+_Note: `github:r-k-b/mtplvcap?ref=add-nix-flake` to be replaced with
+`github:puhitaku/mtplvcap`, after these changes are merged to puhitaku's main branch._
+
+
+For non-[Nix] Linux, see the rest of the instructions:
+
+[Nix]: https://nixos.org/
+
+
 #### 1. Install dependencies
 
 1. Install libusb

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1593287517,
+        "narHash": "sha256-wKAxsNBvKurnLR9SrbQozIAAki9GHBdqce3stJ+1FDw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "136a26be29a9daa04e5f15ee7694e9e92e5a028c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "136a26be29a9daa04e5f15ee7694e9e92e5a028c",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
             echo ""
             echo "This is the dev shell for the MTPLVCAP project."
             echo ""
+            export GOROOT="${pkgs.go}/share/go"
             export MTPLVCAP_DEV_SHELL="entered"
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  description =
+    "Nikon to USB Webcam. Supports older models that Nikon WU does not. Windows/macOS/Linux. No HDMI capture dongle is needed.";
+
+  inputs = {
+    nixpkgs.url =
+      # this old rev supports Go 1.14. See also:
+      # https://lazamar.co.uk/nix-versions/?channel=nixpkgs-unstable&package=go
+      "github:nixos/nixpkgs?rev=136a26be29a9daa04e5f15ee7694e9e92e5a028c";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      allSystems = [
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+
+        # not tested:
+        "aarch64-linux" # 64-bit ARM Linux
+        "x86_64-darwin" # 64-bit Intel macOS
+        "aarch64-darwin" # 64-bit ARM macOS
+      ];
+
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs allSystems
+        (system: f { pkgs = import nixpkgs { inherit system; }; });
+
+      mkProgram = pkgs:
+        pkgs.buildGo114Module {
+          pname = "mtplvcap";
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          buildInputs = [ pkgs.libusb1 ];
+          version = "1.6.2";
+          subPackages = [ ];
+          src = ./.;
+          vendorSha256 = "sha256-J0YW/86VD9nwQ2bq5op0sRLT5/v7W8WfVJ/mmXU2y6o=";
+        };
+    in {
+      apps = forAllSystems ({ pkgs }: {
+        default = {
+          type = "app";
+          program = "${mkProgram pkgs}/bin/mtplvcap";
+        };
+      });
+
+      devShells = forAllSystems ({ pkgs }: {
+        default = pkgs.mkShell {
+          name = "mtplvcap-dev-shell";
+          buildInputs = with pkgs; [ go libusb1 pkg-config ];
+          shellHook = ''
+            if [ "''${MTPLVCAP_DEV_SHELL:-x}" == "entered" ]; then
+              exit 0
+            fi
+            echo ""
+            echo "This is the dev shell for the MTPLVCAP project."
+            echo ""
+            export MTPLVCAP_DEV_SHELL="entered"
+          '';
+        };
+      });
+
+      packages = forAllSystems ({ pkgs }: { default = mkProgram pkgs; });
+    };
+}


### PR DESCRIPTION
Thanks so much for mtplvcap!
I wish I had found it earlier, before I tried using the HDMI live view from my Nikon D5000 :smile: 

I would like to contribute back, by making it a little easier to build & run mtplvcap, for those users who have Nix installed.

With this change, users like that could build & run mtplvcap in a single step, like:

```sh
nix run github:puhitaku/mtplvcap -- -debug server
```

If you want to try that before this PR is accepted, try:

```sh
nix run github:r-k-b/mtplvcap?ref=add-nix-flake -- -debug server
```

---

Is it ok if this PR also adds the Nix build to the `.circleci/config.yaml`?
It would be nice if the nix build stayed up to date, but I understand if you don't want to maintain the Nix build.
