### PR TITLE
Start autofocus and set FPS through CLI

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -364,10 +364,16 @@ mtplvcapとOBSを組み合わせることで、NikonのカメラをHDMIキャプ
 ```sh
 $ ./mtplvcap -help
 Usage of ./mtplvcap:
+  -autofocus-on-startup int
+        autofocus once on startup after X seconds, default=0 (disabled)
+  -autofocus-interval int
+        disable or change the autofocus interval in seconds, default=0 (disabled)
   -backend-go
         force gousb as libusb wrapper (not recommended)
   -debug string
         comma-separated list of debugging options: usb, data, mtp, server
+  -fps int
+        set frame limit, default=0 (disabled)
   -host string
         hostname: default = localhost, specify 0.0.0.0 for public access (default "localhost")
   -max-resolution

--- a/README.md
+++ b/README.md
@@ -351,10 +351,16 @@ I strongly recommend you to compile by yourself for Linux distributions as Linux
 ```sh
 $ ./mtplvcap -help
 Usage of ./mtplvcap:
+  -autofocus-on-startup int
+        autofocus once on startup after X seconds, default=0 (disabled)
+  -autofocus-interval int
+        disable or change the autofocus interval in seconds, default=0 (disabled)
   -backend-go
         force gousb as libusb wrapper (not recommended)
   -debug string
         comma-separated list of debugging options: usb, data, mtp, server
+  -fps int
+        set frame limit, default=0 (disabled)
   -host string
         hostname: default = localhost, specify 0.0.0.0 for public access (default "localhost")
   -max-resolution

--- a/main.go
+++ b/main.go
@@ -35,6 +35,9 @@ func main() {
 	vendorID := flag.String("vendor-id", "0x0", "VID of the camera to search (in hex), default=0x0 (all)")
 	productID := flag.String("product-id", "0x0", "PID of the camera to search (in hex), default=0x0 (all)")
 	maxResolution := flag.Bool("max-resolution", false, "change the resolution to the max (experimental)")
+	afInterval := flag.Int64("autofocus-interval", 0, "disable or change the autofocus interval in seconds, default=0 (disabled)")
+	afFocusNow := flag.Int("autofocus-on-startup", 0, "autofocus once on startup after X seconds, default=0 (disabled)")
+	fps := flag.Int64("fps", 0, "set frame limit, default=0 (disabled)")
 
 	flag.Parse()
 
@@ -101,7 +104,7 @@ func main() {
 		}
 	})
 
-	lvs := mtp.NewLVServer(ctx, dev, *maxResolution)
+	lvs := mtp.NewLVServer(ctx, dev, *maxResolution, *afInterval, *fps)
 	eg.Go(lvs.Run)
 
 	router := http.NewServeMux()
@@ -141,6 +144,10 @@ func main() {
 	})
 
 	log.Info("started")
+
+	if *afFocusNow > 0 {
+		go lvs.AFFocusAfter(time.Duration(*afFocusNow) * time.Second)
+	}
 
 	err = eg.Wait()
 	if err != nil {

--- a/mtp/server.go
+++ b/mtp/server.go
@@ -55,9 +55,14 @@ type LVServer struct {
 	ctx context.Context
 }
 
-func NewLVServer(ctx context.Context, dev Device, maxResolution bool) *LVServer {
+func NewLVServer(ctx context.Context, dev Device, maxResolution bool, afInterval int64, lrFPS int64) *LVServer {
 	eg, egCtx := errgroup.WithContext(ctx)
 
+	afTicker := NewMutableTicker(time.Duration(afInterval) * time.Second)
+	if afInterval > 0 {
+		log.LV.Infof("NewLVServer: enable AF with interval: %d", afInterval)
+		afTicker.Start()
+	}
 	return &LVServer{
 		Frame:        nil,
 		newFrameChan: make(chan bool, 1),
@@ -73,11 +78,11 @@ func NewLVServer(ctx context.Context, dev Device, maxResolution bool) *LVServer 
 
 		maxResolution: maxResolution,
 
-		afInterval: atomic.NewInt64(5),
-		afTicker:   NewMutableTicker(5 * time.Second),
+		afInterval: atomic.NewInt64(afInterval),
+		afTicker:   afTicker,
 		afNowChan:  make(chan bool),
 
-		lrFPS: atomic.NewInt64(0),
+		lrFPS: atomic.NewInt64(lrFPS),
 
 		eg:  eg,
 		ctx: egCtx,
@@ -136,6 +141,21 @@ type InfoPayload struct {
 	Height int      `json:"height"`
 	FPS    int      `json:"fps"`
 	Frame  []byte   `json:"frame"`
+}
+
+func (s *LVServer) AFFocusAfter(after time.Duration) {
+	select {
+	case <-time.After(after):
+	case <-s.ctx.Done():
+		return
+	}
+
+	log.LV.Info("AFFocusAfter: focusing now")
+	select {
+	case s.afNowChan <- true:
+	case <-s.ctx.Done():
+		return
+	}
 }
 
 func (s *LVServer) HandleControl(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This is useful if you want autofocus on startup or on-demand.

Pass a command line flag to autofocus once or on an interval:

```
Usage of ./mtplvcap:
  -af-focus-now int
    	autofocus once on startup after X seconds, default=0 (disabled)
  -af-interval int
    	disable or change the autofocus interval in seconds, default=0 (disabled)
  -fps int
    	set frame limit, default=0 (disabled)
(existing flags omitted)
```