### PR TITLE
Log websocket IP addresses and server host:port

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,6 +119,7 @@ func main() {
 	router.HandleFunc("/control", lvs.HandleControl)
 	router.Handle("/assets/", http.FileServer(public.Root))
 
+	log.Infof("server started on http://%s:%d", *host, *port)
 	srv := http.Server{
 		Addr:    fmt.Sprintf("%s:%d", *host, *port),
 		Handler: logging.HTTPLogHandler(router),

--- a/mtp/server.go
+++ b/mtp/server.go
@@ -88,8 +88,9 @@ func NewLVServer(ctx context.Context, dev Device, maxResolution bool) *LVServer 
 
 func (s *LVServer) HandleStream(w http.ResponseWriter, r *http.Request) {
 	ws, err := s.upgrader.Upgrade(w, r, nil)
+	log.LV.Infof("HandleStream %s: websocket client connected", ws.RemoteAddr())
 	if err != nil {
-		log.LV.Errorf("HandleStream: failed to upgrade: %s", err)
+		log.LV.Errorf("HandleStream %s: failed to upgrade: %s", ws.RemoteAddr(), err)
 	}
 	defer ws.Close()
 
@@ -98,7 +99,7 @@ func (s *LVServer) HandleStream(w http.ResponseWriter, r *http.Request) {
 		var mes struct{}
 		err := ws.ReadJSON(&mes)
 		if err != nil {
-			log.LV.Errorf("HandleStream: failed to read a message: %s", err)
+			log.LV.Errorf("HandleStream %s: failed to read a message: %s", ws.RemoteAddr(), err)
 			s.unregisterStreamClient(ws)
 			return
 		}
@@ -140,8 +141,9 @@ type InfoPayload struct {
 
 func (s *LVServer) HandleControl(w http.ResponseWriter, r *http.Request) {
 	ws, err := s.upgrader.Upgrade(w, r, nil)
+	log.LV.Infof("HandleControl %s: websocket client connected", ws.RemoteAddr())
 	if err != nil {
-		log.LV.Errorf("HandleControl: failed to upgrade: %s", err)
+		log.LV.Errorf("HandleControl %s: failed to upgrade: %s", ws.RemoteAddr(), err)
 	}
 	defer ws.Close()
 
@@ -161,7 +163,7 @@ func (s *LVServer) HandleControl(w http.ResponseWriter, r *http.Request) {
 		var p ControlPayload
 		err := ws.ReadJSON(&p)
 		if err != nil {
-			log.LV.Errorf("HandleControl: failed to read a message: %s", err)
+			log.LV.Errorf("HandleControl %s: failed to read a message: %s", ws.RemoteAddr(), err)
 			s.unregisterControlClient(ws)
 			return
 		}
@@ -170,10 +172,10 @@ func (s *LVServer) HandleControl(w http.ResponseWriter, r *http.Request) {
 			setInfo(p.AFInterval, nil)
 
 			if *p.AFInterval > 0 {
-				log.LV.Debug("HandleControl: enable AF")
+				log.LV.Debugf("HandleControl %s: enable AF", ws.RemoteAddr())
 				s.afTicker.Start()
 			} else {
-				log.LV.Debug("HandleControl: disable AF")
+				log.LV.Debugf("HandleControl %s: disable AF", ws.RemoteAddr())
 				s.afTicker.Stop()
 				continue
 			}
@@ -181,13 +183,13 @@ func (s *LVServer) HandleControl(w http.ResponseWriter, r *http.Request) {
 			s.afInterval.Store(*p.AFInterval)
 			s.afTicker.SetInterval(time.Duration(*p.AFInterval) * time.Second)
 			if err != nil {
-				log.LV.Debugf("HandleControl: failed to set interval: %d", *p.AFInterval)
+				log.LV.Debugf("HandleControl %s: failed to set interval: %d", ws.RemoteAddr(), *p.AFInterval)
 			}
-			log.LV.Debugf("HandleControl: set AF interval: %d", *p.AFInterval)
+			log.LV.Debugf("HandleControl %s: set AF interval: %d", ws.RemoteAddr(), *p.AFInterval)
 		}
 
 		if p.AFFocusNow != nil && *p.AFFocusNow {
-			log.LV.Debug("HandleControl: focus now")
+			log.LV.Debugf("HandleControl %s: focus now", ws.RemoteAddr())
 			select {
 			case s.afNowChan <- true:
 			default:
@@ -197,26 +199,26 @@ func (s *LVServer) HandleControl(w http.ResponseWriter, r *http.Request) {
 		if p.LRFPS != nil {
 			setInfo(nil, p.LRFPS)
 			if *p.LRFPS > 0 {
-				log.LV.Debugf("HandleControl: set rate limit: %d", *p.LRFPS)
+				log.LV.Debugf("HandleControl %s: set rate limit: %d", ws.RemoteAddr(), *p.LRFPS)
 			} else {
-				log.LV.Debug("HandleControl: disable rate limit")
+				log.LV.Debugf("HandleControl %s: disable rate limit", ws.RemoteAddr())
 			}
 			s.lrFPS.Store(*p.LRFPS)
 		}
 
 		if p.ISO != nil {
-			log.LV.Debugf("HandleControl: set ISO: %d", *p.ISO)
+			log.LV.Debugf("HandleControl %s: set ISO: %d", ws.RemoteAddr(), *p.ISO)
 			err = s.setISO(*p.ISO)
 			if err != nil {
-				log.LV.Errorf("HandleControl: failed to set ISO: %s", err)
+				log.LV.Errorf("HandleControl %s: failed to set ISO: %s", ws.RemoteAddr(), err)
 			}
 		}
 
 		if p.FN != nil {
-			log.LV.Debugf("HandleControl: set f-number: %s", *p.FN)
+			log.LV.Debugf("HandleControl %s: set f-number: %s", ws.RemoteAddr(), *p.FN)
 			err = s.setFN(*p.FN)
 			if err != nil {
-				log.LV.Errorf("HandleControl: failed to set f-number: %s", err)
+				log.LV.Errorf("HandleControl %s: failed to set f-number: %s", ws.RemoteAddr(), err)
 			}
 		}
 	}


### PR DESCRIPTION
- Log host:port
- Log client IP for every websocket message received

Example:
```
$ mtplvcap -debug server
[0000]  INFO usb: found: ...
[0000]  INFO usb: found: ...
[0000]  WARN mtp: detected more than 1 device
[0000]  INFO mtp: opening the detected Nikon .....
[0000]  INFO main: server started on http://localhost:42839
[0000]  INFO main: started
[0000] DEBUG lv: manufacturer = NIKON, product = NIKON ..., serialnumber = ...
[0000] DEBUG lv: model didn't match, falling back to the generic model 
[0000]  INFO lv: HandleStream 127.0.0.1:40964: websocket client connected
[0000]  INFO lv: HandleStream 127.0.0.1:40974: websocket client connected
[0000]  INFO lv: HandleControl 127.0.0.1:40980: websocket client connected
[0001]  INFO lv: getting available resolutions
[0001]  INFO lv: available resolutions (higher is larger): [1 2 3]
[0001]  INFO lv: automatically use the largest choice: 3
[0002]  INFO lv: HandleControl 127.0.0.1:40994: websocket client connected
[0005] DEBUG lv: HandleControl 127.0.0.1:40994: set rate limit: 30
[0006] DEBUG lv: HandleControl 127.0.0.1:40994: disable rate limit
[0008] ERROR lv: HandleControl 127.0.0.1:40994: failed to read a message: websocket: close 1001 (going away)
[0008]  INFO http: GET /control 127.0.0.1:40994
```

The http `GET` logs are also logging IP addresses.